### PR TITLE
Enable proto descriptor retrieval via basic auth

### DIFF
--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParser.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParser.java
@@ -152,7 +152,12 @@ public class ProtobufInputRowParser implements ByteBufferInputRowParser
         throw new ParseException(e, "Descriptor not found in class path or malformed URL:" + descriptorFilePath);
       }
       try {
-        fin = url.openConnection().getInputStream();
+        URLConnection urlConnection = url.openConnection();
+        if (url.getUserInfo() != null) {
+            String basicAuth = "Basic " + javax.xml.bind.DatatypeConverter.printBase64Binary(url.getUserInfo().getBytes());
+            urlConnection.setRequestProperty("Authorization", basicAuth);
+        }
+        fin = urlConnection.getInputStream();
       }
       catch (IOException e) {
         throw new ParseException(e, "Cannot read descriptor file: " + url);


### PR DESCRIPTION
### Description

Currently, Protobuf Descriptors can only be retrieved from the local filesystem, or unauthorized URLs. 

This commit introduces the ability to retrieve descriptors via authenticated URLs.

<hr>

This PR has:
- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
