### PR TITLE
Enable proto descriptor retrieval via basic auth

### DIFF
--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParser.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParser.java
@@ -46,7 +46,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.ByteBuffer;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -152,7 +154,13 @@ public class ProtobufInputRowParser implements ByteBufferInputRowParser
         throw new ParseException(e, "Descriptor not found in class path or malformed URL:" + descriptorFilePath);
       }
       try {
-        fin = url.openConnection().getInputStream();
+        URLConnection urlConnection = url.openConnection();
+        if (url.getUserInfo() != null) {
+          String basicAuth = "Basic " + Base64.getEncoder().encodeToString(
+                                            url.getUserInfo().getBytes());
+          urlConnection.setRequestProperty("Authorization", basicAuth);
+        }
+        fin = urlConnection.getInputStream();
       }
       catch (IOException e) {
         throw new ParseException(e, "Cannot read descriptor file: " + url);

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParser.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParser.java
@@ -48,6 +48,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -157,7 +158,7 @@ public class ProtobufInputRowParser implements ByteBufferInputRowParser
         URLConnection urlConnection = url.openConnection();
         if (url.getUserInfo() != null) {
           String basicAuth = "Basic " + Base64.getEncoder().encodeToString(
-                                            url.getUserInfo().getBytes());
+                                            url.getUserInfo().getBytes(StandardCharsets.UTF_8));
           urlConnection.setRequestProperty("Authorization", basicAuth);
         }
         fin = urlConnection.getInputStream();


### PR DESCRIPTION
### Description

Currently, Protobuf Descriptors can only be retrieved from the local filesystem, or unauthorized URLs. 

This commit introduces the ability to retrieve descriptors via authenticated URLs.

<hr>

This PR has:
- [X] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr> 

No unit tests were added since a test relying on an actual authenticated https get request would be flaky at best. 

Wrote a simple hello world script to check that it works.

```
package hello;
import java.io.IOException;
import java.io.InputStream;
import java.net.URL;
import java.net.URLConnection;
import java.nio.charset.StandardCharsets;
import java.util.Base64;

public class HelloWorld {
  public static void main(String[] args) {
    try {
      //   URL url = new URL("http://user:pass@domain.com/url");
      URL url = new URL(
          "https://github.com/apache/druid/blob/master/docs/development/build.md");
      URLConnection urlConnection = url.openConnection();
      if (url.getUserInfo() != null) {
        String basicAuth = "Basic " + Base64.getEncoder().encodeToString(
                                          url.getUserInfo().getBytes());
        urlConnection.setRequestProperty("Authorization", basicAuth);
      }
      InputStream in = urlConnection.getInputStream();

      System.out.println("FILE: " +
                         new String(in.readAllBytes(), StandardCharsets.UTF_8));
    } catch (IOException e) {
      System.out.println("Cannot read descriptor file: " + e.getMessage());
    }
  }
}
```